### PR TITLE
Updates for compatability with March 2017 Kaldi version

### DIFF
--- a/src/Nnet3LatgenFasterDecoder.h
+++ b/src/Nnet3LatgenFasterDecoder.h
@@ -17,7 +17,7 @@
 #define APIAI_DECODER_NNET3LATGENFASTERDECODER_H_
 
 #include "OnlineDecoder.h"
-#include "online2/online-nnet3-decoding.h"
+#include "online2/online-nnet3-decoding.h"          
 #include "online2/online-nnet2-feature-pipeline.h"
 
 namespace apiai {
@@ -47,13 +47,14 @@ private:
     // feature_config includes configuration for the iVector adaptation,
     // as well as the basic features.
     kaldi::OnlineNnet2FeaturePipelineConfig feature_config_;
-    kaldi::OnlineNnet3DecodingConfig nnet3_decoding_config_;
+    kaldi::nnet3::NnetSimpleLoopedComputationOptions decodable_opts_;  
+    kaldi::LatticeFasterDecoderConfig decoder_opts_;                   
 
     kaldi::OnlineNnet2FeaturePipelineInfo *feature_info_;
     fst::Fst<fst::StdArc> *decode_fst_;
     kaldi::TransitionModel *trans_model_;
     kaldi::nnet3::AmNnetSimple *nnet_;
-
+    kaldi::nnet3::DecodableNnetSimpleLoopedInfo *decodable_info_;     
 
     kaldi::OnlineIvectorExtractorAdaptationState *adaptation_state_;
     kaldi::OnlineNnet2FeaturePipeline *feature_pipeline_;

--- a/src/OnlineDecoder.cc
+++ b/src/OnlineDecoder.cc
@@ -105,7 +105,7 @@ void OnlineDecoder::GetRecognitionResult(DecodedData &input, RecognitionResult *
 	  output->text = outss.str();
 }
 
-void OnlineDecoder::GetRecognitionResult(vector<DecodedData> &input, vector<RecognitionResult> *output) {
+void OnlineDecoder::GetRecognitionResult(std::vector<DecodedData> &input, std::vector<RecognitionResult> *output) {
 	for (int i = 0; i < input.size(); i++) {
 		RecognitionResult result;
 		GetRecognitionResult(input.at(i), &result);
@@ -194,7 +194,7 @@ void OnlineDecoder::Decode(Request &request, Response &response) {
 
 			if ((intermediate_samples_interval > 0) && (samp_counter > (intermediate_samples_interval * intermediate_counter))) {
 				intermediate_counter++;
-				vector<DecodedData> decodeData;
+				std::vector<DecodedData> decodeData;
 				if (DecodeIntermediate(1, &decodeData) > 0) {
 					DecodedData &data = decodeData.at(0);
 					if (!wordsEquals(prev_words, data.words)) {
@@ -236,7 +236,7 @@ void OnlineDecoder::Decode(Request &request, Response &response) {
 		KALDI_VLOG(1) << "Input finished @ " << getMillisecondsSince(start_time) << " ms (audio length: " << (samp_counter / (request.Frequency() / 1000)) << " ms)";
 		InputFinished();
 
-		vector<DecodedData> result;
+		std::vector<DecodedData> result;
 
 		int32 decoded = Decode(true, request.BestCount(), &result);
 
@@ -244,7 +244,7 @@ void OnlineDecoder::Decode(Request &request, Response &response) {
 			response.SetError("Best-path failed");
 			KALDI_WARN << "Best-path failed";
 		} else {
-			vector<RecognitionResult> recognitionResults;
+			std::vector<RecognitionResult> recognitionResults;
 			GetRecognitionResult(result, &recognitionResults);
 			response.SetResult(recognitionResults, requestInterrupted, (samp_counter / (request.Frequency() / 1000)));
 			KALDI_VLOG(1) << "Recognized @ " << getMillisecondsSince(start_time) << " ms";
@@ -258,11 +258,11 @@ void OnlineDecoder::Decode(Request &request, Response &response) {
 	}
 };
 
-int32 OnlineDecoder::DecodeIntermediate(int bestCount, vector<DecodedData> *result) {
+int32 OnlineDecoder::DecodeIntermediate(int bestCount, std::vector<DecodedData> *result) {
 	return Decode(false, bestCount, result);
 }
 
-int32 OnlineDecoder::Decode(bool end_of_utterance, int bestCount, vector<DecodedData> *result) {
+int32 OnlineDecoder::Decode(bool end_of_utterance, int bestCount, std::vector<DecodedData> *result) {
 	kaldi::CompactLattice clat;
 	GetLattice(&clat, end_of_utterance);
 

--- a/src/OnlineDecoder.h
+++ b/src/OnlineDecoder.h
@@ -99,7 +99,7 @@ private:
 	kaldi::int32 Decode(bool end_of_utterance, int bestCount, std::vector<DecodedData> *result);
 
 	void GetRecognitionResult(DecodedData &input, RecognitionResult *output);
-	void GetRecognitionResult(vector<DecodedData> &input, vector<RecognitionResult> *output);
+	void GetRecognitionResult(std::vector<DecodedData> &input, std::vector<RecognitionResult> *output);
 };
 
 } /* namespace apiai */


### PR DESCRIPTION
These changes allow the api.ai server code to work with the newer version of Kaldi which has a modified api for SingleUtteranceNnet3Decoder.  The changes follow closely the Kaldi code found in..
online2bin/online2-wav-nnet3-latgen-faster.cc