### PR TITLE
Don't link to removed thread library

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -20,7 +20,7 @@ ADDLIBS = $(KALDI_PATH)/online2/kaldi-online2.a $(KALDI_PATH)/ivector/kaldi-ivec
           $(KALDI_PATH)/nnet2/kaldi-nnet2.a $(KALDI_PATH)/nnet3/kaldi-nnet3.a $(KALDI_PATH)/lat/kaldi-lat.a \
           $(KALDI_PATH)/decoder/kaldi-decoder.a  $(KALDI_PATH)/cudamatrix/kaldi-cudamatrix.a \
           $(KALDI_PATH)/feat/kaldi-feat.a $(KALDI_PATH)/transform/kaldi-transform.a $(KALDI_PATH)/gmm/kaldi-gmm.a \
-          $(KALDI_PATH)/thread/kaldi-thread.a $(KALDI_PATH)/hmm/kaldi-hmm.a $(KALDI_PATH)/tree/kaldi-tree.a \
+          $(KALDI_PATH)/hmm/kaldi-hmm.a $(KALDI_PATH)/tree/kaldi-tree.a \
           $(KALDI_PATH)/matrix/kaldi-matrix.a $(KALDI_PATH)/fstext/kaldi-fstext.a \
           $(KALDI_PATH)/util/kaldi-util.a $(KALDI_PATH)/base/kaldi-base.a 
           


### PR DESCRIPTION
Hi there, I've been working on getting this working for a project at work. In https://github.com/kaldi-asr/kaldi/commit/6cc8e3ad79fe1a720451676b5b17866f3729d411 the kaldi project removed the vendored pthread library to use the STL thread library. This patch removes the now-deleted lib so it can compile with the latest kaldi master branch.