### PR TITLE
Check NumFramesDecoded when using intermediate

### DIFF
--- a/src/Nnet3LatgenFasterDecoder.cc
+++ b/src/Nnet3LatgenFasterDecoder.cc
@@ -170,4 +170,9 @@ void Nnet3LatgenFasterDecoder::GetLattice(kaldi::CompactLattice *clat, bool end_
 	}
 }
 
+
+int32 Nnet3LatgenFasterDecoder::NumFramesDecoded() const {
+    return decoder_->NumFramesDecoded();
+}
+
 } /* namespace apiai */

--- a/src/Nnet3LatgenFasterDecoder.h
+++ b/src/Nnet3LatgenFasterDecoder.h
@@ -38,6 +38,7 @@ protected:
 	virtual void InputFinished();
 	virtual void GetLattice(kaldi::CompactLattice *clat, bool end_of_utterance);
 	virtual void CleanUp();
+    virtual int32 NumFramesDecoded() const;
 private:
 	std::string nnet3_rxfilename_;
 

--- a/src/OnlineDecoder.cc
+++ b/src/OnlineDecoder.cc
@@ -173,7 +173,6 @@ void OnlineDecoder::Decode(Request &request, Response &response) {
 
 		int time_left_ms = decoding_timeout_ms;
 		while ((wave_part = request.NextChunk(samples_left, time_left_ms)) != NULL) {
-
 			samp_counter += wave_part->Dim();
 
 			if (AcceptWaveform(request.Frequency(), *wave_part, do_endpointing) == false && do_endpointing) {
@@ -192,7 +191,9 @@ void OnlineDecoder::Decode(Request &request, Response &response) {
 				samples_left = std::min(max_samples_limit - samp_counter, samples_per_chunk);
 			}
 
-			if ((intermediate_samples_interval > 0) && (samp_counter > (intermediate_samples_interval * intermediate_counter))) {
+			if ((intermediate_samples_interval > 0)
+                && (samp_counter > (intermediate_samples_interval * intermediate_counter))
+                && NumFramesDecoded() > 0) {
 				intermediate_counter++;
 				std::vector<DecodedData> decodeData;
 				if (DecodeIntermediate(1, &decodeData) > 0) {

--- a/src/OnlineDecoder.h
+++ b/src/OnlineDecoder.h
@@ -68,6 +68,10 @@ protected:
 	 * Calculate intermediate results
 	 */
 	virtual kaldi::int32 DecodeIntermediate(int bestCount, std::vector<DecodedData> *result);
+    /**
+     * Return the number of frames decoded thus far
+     */
+    virtual int32 NumFramesDecoded() const = 0;
 
 	std::string word_syms_rxfilename_;
 	kaldi::BaseFloat chunk_length_secs_;


### PR DESCRIPTION
It happens that after AcceptWaveform() the number of frames decoded can still be 0 for a few passes. If NumFraamesDecoded() is not considered, the following error will occur:

> ERROR (fcgi-nnet3-decoder[5.2.68~1391-aedc2]:GetLattice():online-nnet3-decoding.cc:57) You cannot get a lattice if you decoded no frames.